### PR TITLE
Add Chrome extension support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && npm run build:sw",
+    "build:sw": "tsc src/background.ts --outDir dist --target ES2020 --module ES2020",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "Digital Zen Time",
+  "description": "Automatic time tracking in Chrome",
+  "version": "1.0.0",
+  "action": {
+    "default_popup": "index.html",
+    "default_title": "Digital Zen Time"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "permissions": [
+    "storage",
+    "tabs",
+    "idle",
+    "alarms"
+  ],
+  "host_permissions": ["<all_urls>"]
+}

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,68 @@
+interface DailyData {
+  [domain: string]: number;
+}
+
+function getTodayKey() {
+  return new Date().toISOString().split('T')[0];
+}
+
+let currentDomain = '';
+let lastStart = Date.now();
+let isIdle = false;
+
+function saveTime(domain: string, delta: number) {
+  if (!domain || delta <= 0) return;
+  const key = `timetrack_daily_${getTodayKey()}`;
+  chrome.storage.local.get([key], res => {
+    const data: DailyData = res[key] || {};
+    data[domain] = (data[domain] || 0) + delta;
+    chrome.storage.local.set({ [key]: data });
+  });
+}
+
+function updateActiveDomain() {
+  chrome.tabs.query({ active: true, lastFocusedWindow: true }, tabs => {
+    const tab = tabs[0];
+    if (tab && tab.url) {
+      const url = new URL(tab.url);
+      currentDomain = url.hostname;
+    } else {
+      currentDomain = '';
+    }
+    lastStart = Date.now();
+  });
+}
+
+function handleTabChange() {
+  const now = Date.now();
+  if (currentDomain && !isIdle) {
+    const delta = Math.floor((now - lastStart) / 1000);
+    saveTime(currentDomain, delta);
+  }
+  updateActiveDomain();
+}
+
+chrome.tabs.onActivated.addListener(handleTabChange);
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tab.active && changeInfo.url) {
+    handleTabChange();
+  }
+});
+chrome.windows.onFocusChanged.addListener(handleTabChange);
+
+chrome.idle.onStateChanged.addListener(state => {
+  const now = Date.now();
+  if (state === 'idle' || state === 'locked') {
+    isIdle = true;
+    if (currentDomain) {
+      const delta = Math.floor((now - lastStart) / 1000);
+      saveTime(currentDomain, delta);
+    }
+  } else {
+    isIdle = false;
+    lastStart = now;
+  }
+});
+
+// Initialize
+updateActiveDomain();

--- a/src/components/CategoryManager.tsx
+++ b/src/components/CategoryManager.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Plus, Edit2, Trash2, Globe } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { setItem } from '@/lib/storage';
 
 interface Category {
   id: string;
@@ -28,7 +29,7 @@ export const CategoryManager: React.FC<CategoryManagerProps> = ({ categories, on
 
   const colors = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#84cc16'];
 
-  const addCategory = () => {
+  const addCategory = async () => {
     if (newCategoryName.trim()) {
       const newCategory: Category = {
         id: Date.now().toString(),
@@ -38,19 +39,19 @@ export const CategoryManager: React.FC<CategoryManagerProps> = ({ categories, on
       };
       const updatedCategories = [...categories, newCategory];
       onCategoriesChange(updatedCategories);
-      localStorage.setItem('timetrack_categories', JSON.stringify(updatedCategories));
+      await setItem('timetrack_categories', updatedCategories);
       setNewCategoryName('');
       setIsAddingCategory(false);
     }
   };
 
-  const deleteCategory = (categoryId: string) => {
+  const deleteCategory = async (categoryId: string) => {
     const updatedCategories = categories.filter(cat => cat.id !== categoryId);
     onCategoriesChange(updatedCategories);
-    localStorage.setItem('timetrack_categories', JSON.stringify(updatedCategories));
+    await setItem('timetrack_categories', updatedCategories);
   };
 
-  const addDomainToCategory = (categoryId: string, domain: string) => {
+  const addDomainToCategory = async (categoryId: string, domain: string) => {
     if (!domain.trim()) return;
     
     const updatedCategories = categories.map(cat => {
@@ -60,11 +61,11 @@ export const CategoryManager: React.FC<CategoryManagerProps> = ({ categories, on
       return cat;
     });
     onCategoriesChange(updatedCategories);
-    localStorage.setItem('timetrack_categories', JSON.stringify(updatedCategories));
+    await setItem('timetrack_categories', updatedCategories);
     setNewDomain('');
   };
 
-  const removeDomainFromCategory = (categoryId: string, domain: string) => {
+  const removeDomainFromCategory = async (categoryId: string, domain: string) => {
     const updatedCategories = categories.map(cat => {
       if (cat.id === categoryId) {
         return { ...cat, domains: cat.domains.filter(d => d !== domain) };
@@ -72,7 +73,7 @@ export const CategoryManager: React.FC<CategoryManagerProps> = ({ categories, on
       return cat;
     });
     onCategoriesChange(updatedCategories);
-    localStorage.setItem('timetrack_categories', JSON.stringify(updatedCategories));
+    await setItem('timetrack_categories', updatedCategories);
   };
 
   return (

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -7,30 +7,31 @@ import { QuickStats } from '@/components/QuickStats';
 import { RecentActivity } from '@/components/RecentActivity';
 import { AchievementPanel } from '@/components/AchievementPanel';
 import { Card } from '@/components/ui/card';
+import { getItem, setItem } from '@/lib/storage';
 
 export const Dashboard = () => {
   const [timeData, setTimeData] = useState(null);
   const [categories, setCategories] = useState([]);
 
   useEffect(() => {
-    // Load data from localStorage
+    // Load data from storage
     loadDashboardData();
-    
+
     // Set up interval to refresh data
     const interval = setInterval(loadDashboardData, 5000);
     return () => clearInterval(interval);
   }, []);
 
-  const loadDashboardData = () => {
-    const savedData = localStorage.getItem('timetrack_daily_data');
-    const savedCategories = localStorage.getItem('timetrack_categories');
-    
+  const loadDashboardData = async () => {
+    const savedData = await getItem('timetrack_daily_data');
+    const savedCategories = await getItem('timetrack_categories');
+
     if (savedData) {
-      setTimeData(JSON.parse(savedData));
+      setTimeData(savedData);
     }
-    
+
     if (savedCategories) {
-      setCategories(JSON.parse(savedCategories));
+      setCategories(savedCategories);
     } else {
       // Default categories
       const defaultCategories = [
@@ -41,7 +42,7 @@ export const Dashboard = () => {
         { id: '5', name: 'חדשות', color: '#8b5cf6', domains: ['ynet.co.il', 'walla.co.il'] },
       ];
       setCategories(defaultCategories);
-      localStorage.setItem('timetrack_categories', JSON.stringify(defaultCategories));
+      await setItem('timetrack_categories', defaultCategories);
     }
   };
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,20 @@
+export async function getItem<T = any>(key: string): Promise<T | null> {
+  if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+    return new Promise(resolve => {
+      chrome.storage.local.get([key], result => {
+        resolve(result[key] ?? null);
+      });
+    });
+  }
+  const data = localStorage.getItem(key);
+  return data ? JSON.parse(data) : null;
+}
+
+export async function setItem(key: string, value: any): Promise<void> {
+  if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+    return new Promise(resolve => {
+      chrome.storage.local.set({ [key]: value }, () => resolve());
+    });
+  }
+  localStorage.setItem(key, JSON.stringify(value));
+}

--- a/src/lib/timeTracker.ts
+++ b/src/lib/timeTracker.ts
@@ -1,4 +1,6 @@
 
+import { getItem } from '@/lib/storage';
+
 export interface TimeEntry {
   domain: string;
   time: number; // in seconds
@@ -25,95 +27,19 @@ export class TimeTracker {
   static init(): TimeTracker {
     if (!TimeTracker.instance) {
       TimeTracker.instance = new TimeTracker();
-      TimeTracker.instance.startTracking();
     }
     return TimeTracker.instance;
   }
 
-  private startTracking() {
-    // In a real Chrome extension, this would use Chrome APIs
-    // For demo purposes, we'll simulate tracking
-    this.simulateTracking();
-    this.setupIdleDetection();
-  }
+  // Tracking is handled by the background service worker using Chrome APIs
 
-  private simulateTracking() {
-    // Simulate some realistic browsing data
-    const domains = [
-      'github.com', 'stackoverflow.com', 'docs.google.com',
-      'youtube.com', 'facebook.com', 'twitter.com',
-      'ynet.co.il', 'walla.co.il'
-    ];
-
+  async getTodayData(): Promise<DailyData> {
     const today = new Date().toISOString().split('T')[0];
-    const existingData = this.getTodayData();
-
-    if (Object.keys(existingData).length === 0) {
-      // Generate some sample data for demo
-      const sampleData: DailyData = {};
-      domains.forEach(domain => {
-        sampleData[domain] = Math.floor(Math.random() * 3600) + 300; // 5 minutes to 1 hour
-      });
-      
-      localStorage.setItem(`timetrack_daily_${today}`, JSON.stringify(sampleData));
-    }
-
-    // Update data every 5 seconds for demo
-    setInterval(() => {
-      this.updateCurrentDomainTime();
-    }, 5000);
+    const data = await getItem(`timetrack_daily_${today}`);
+    return data || {};
   }
 
-  private setupIdleDetection() {
-    // Detect user activity
-    const events = ['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart'];
-    
-    events.forEach(event => {
-      document.addEventListener(event, () => {
-        this.lastActivity = Date.now();
-        if (!this.isActive) {
-          this.isActive = true;
-          this.startTime = Date.now();
-        }
-      }, true);
-    });
-
-    // Check for idle state every 30 seconds
-    setInterval(() => {
-      const now = Date.now();
-      if (now - this.lastActivity > this.idleThreshold) {
-        this.isActive = false;
-      }
-    }, 30000);
-  }
-
-  private updateCurrentDomainTime() {
-    if (!this.isActive) return;
-
-    // In a real extension, this would get the current tab's domain
-    // For demo, we'll randomly pick from common domains
-    const domains = ['github.com', 'youtube.com', 'facebook.com'];
-    const randomDomain = domains[Math.floor(Math.random() * domains.length)];
-    
-    const today = new Date().toISOString().split('T')[0];
-    const dailyData = this.getTodayData();
-    
-    if (!dailyData[randomDomain]) {
-      dailyData[randomDomain] = 0;
-    }
-    
-    dailyData[randomDomain] += 5; // Add 5 seconds
-    
-    localStorage.setItem(`timetrack_daily_${today}`, JSON.stringify(dailyData));
-  }
-
-  getTodayData(): DailyData {
-    const today = new Date().toISOString().split('T')[0];
-    const data = localStorage.getItem(`timetrack_daily_${today}`);
-    return data ? JSON.parse(data) : {};
-  }
-
-  getWeeklyData(): WeeklyData {
+  async getWeeklyData(): Promise<WeeklyData> {
     const weeklyData: WeeklyData = {};
     const today = new Date();
     
@@ -122,17 +48,17 @@ export class TimeTracker {
       date.setDate(date.getDate() - i);
       const dateStr = date.toISOString().split('T')[0];
       
-      const dayData = localStorage.getItem(`timetrack_daily_${dateStr}`);
+      const dayData = await getItem(`timetrack_daily_${dateStr}`);
       if (dayData) {
-        weeklyData[dateStr] = JSON.parse(dayData);
+        weeklyData[dateStr] = dayData;
       }
     }
     
     return weeklyData;
   }
 
-  getDomainCategory(domain: string): string {
-    const categories = JSON.parse(localStorage.getItem('timetrack_categories') || '[]');
+  async getDomainCategory(domain: string): Promise<string> {
+    const categories = await getItem('timetrack_categories') || [];
     
     for (const category of categories) {
       if (category.domains.includes(domain)) {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,24 +4,26 @@ import { Dashboard } from '@/components/Dashboard';
 import { Onboarding } from '@/components/Onboarding';
 import { Navigation } from '@/components/Navigation';
 import { TimeTracker } from '@/lib/timeTracker';
+import { getItem, setItem } from '@/lib/storage';
 
 const Index = () => {
   const [isFirstTime, setIsFirstTime] = useState(false);
   const [currentView, setCurrentView] = useState('dashboard');
 
   useEffect(() => {
-    // Check if this is first time user
-    const hasSeenOnboarding = localStorage.getItem('timetrack_onboarding_complete');
-    if (!hasSeenOnboarding) {
-      setIsFirstTime(true);
-    }
+    (async () => {
+      const hasSeenOnboarding = await getItem('timetrack_onboarding_complete');
+      if (!hasSeenOnboarding) {
+        setIsFirstTime(true);
+      }
+    })();
 
     // Initialize time tracker
     TimeTracker.init();
   }, []);
 
-  const handleOnboardingComplete = () => {
-    localStorage.setItem('timetrack_onboarding_complete', 'true');
+  const handleOnboardingComplete = async () => {
+    await setItem('timetrack_onboarding_complete', 'true');
     setIsFirstTime(false);
   };
 


### PR DESCRIPTION
## Summary
- add a Chrome extension manifest
- implement background service worker for domain tracking
- create wrapper for chrome storage
- update React components to use new storage helpers
- add build step for service worker

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6874cbbcb4248324bb5d6bcaa5207b60